### PR TITLE
Revert "Added file support for copy"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ opts = ReqOpts(None, 'git')
 
 setup(
     name='vertica-python',
-    version='0.3.5',
+    version='0.3.4',
     description='A native Python client for the Vertica database.',
     author='Justin Berka, Alex Kim',
     author_email='justin.berka@gmail.com, alex.kim@uber.com',

--- a/vertica_python/__init__.py
+++ b/vertica_python/__init__.py
@@ -6,7 +6,7 @@ from vertica_python.vertica.connection import Connection
 # Main module for this library.
 
 # The version number of this library.
-version_info = (0, 3, 5)
+version_info = (0, 3, 4)
 __version__ = '.'.join(map(str, version_info))
 
 __author__ = 'Uber Technologies, Inc'

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -113,10 +113,7 @@ class Cursor(object):
     #
     # todo: input stream
     def copy(self, sql, data):
-        # Legacy support
-        self.copy_string(sql, data)
 
-    def _copy_internal(self, sql, datagen):
         if self.closed():
             raise errors.Error('Cursor is closed')
 
@@ -129,23 +126,11 @@ class Cursor(object):
                 break
             elif isinstance(message, messages.CopyInResponse):
                 # write stuff
-                for line in datagen:
-                    self.connection.write(messages.CopyData(line))
+                self.connection.write(messages.CopyData(data))
                 self.connection.write(messages.CopyDone())
 
         if self.error is not None:
             raise self.error
-
-    def copy_string(self, sql, data):
-        self._copy_internal(sql, [data])
-
-
-    def copy_file(self, sql, data, decoder=None):
-        if decoder=None:
-            self._copy_internal(sql, data)
-        else:
-            self._copy_internal(sql, (line.decode(decoder) for line in data))
-
 
     #
     # Internal


### PR DESCRIPTION
Give `copy` the option to read from file object instead of string.

If the datafile arg is set to a file object, it will read lines from it and write each line to the copy stream.
If the datafile is not specified, or set to `None`, it will pass in the string.

I might consider a different function signature, since it's not obvious that string and datafile are exclusive, or that string is silently ignored if a datafile is present, but I wanted to ensure that the existing code doesn't inadvertently break.

EDIT: on one hand, I want to see how this revert thing works. On the other, I need to fix a typo. On the third, I want to see if we can do a fast-forward merge.