### PR TITLE
Correctly propagate TimedOutError

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -185,6 +185,8 @@ class Connection(object):
             else:
                 self.close()
                 raise errors.TimedOutError("Connection timed out")
+        except errors.TimedOutError:
+            raise
         except Exception as e:
             self.close_socket()
             raise errors.ConnectionError(e.message)


### PR DESCRIPTION
Before: TimedOutError was discarded; instead a ConnectionError with message 'Connection timed out' was raised to client
After: TimedOutError in its fully glory gets raised to client