### PR TITLE
removed reset_connection from cursor.execute and a bug fix

### DIFF
--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -58,8 +58,7 @@ class Cursor(object):
 
         self.rowcount = 0
         if self.last_execution:
-            # ToDo: can just empty the message buffer in connection if easy to do
-            self.connection.reset_connection()
+            self._message = None
         self.last_execution = operation
         self.connection.write(messages.Query(operation))
 
@@ -83,7 +82,9 @@ class Cursor(object):
             self._message = self.connection.read_message()
             return row
         else:
-            self.connection.process_message(self._message)
+            while not isinstance(self._message, messages.ReadyForQuery):
+                self.connection.process_message(self._message)
+                self._message = self.connection.read_message()
 
     def iterate(self):
         row = self.fetchone()

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -86,6 +86,9 @@ class Cursor(object):
                 self.connection.process_message(self._message)
                 self._message = self.connection.read_message()
 
+            if isinstance(self._message, messages.ReadyForQuery):
+                self.connection.transaction_status = self._message.transaction_status
+
     def iterate(self):
         row = self.fetchone()
         while row:


### PR DESCRIPTION
- reset_connection in execute caused every call to behave as independent transaction
- when results are streamed for SELECT calls, the messages are to be processed till vertica returns ReadyForQuery