### PR TITLE
Automatically close db connection and cursor after user has finished ite...

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,30 @@ for row in cur.iterate():
     print(row)
 # {'id': 1, 'value': 'something'}
 # {'id': 2, 'value': 'something_else'}
-
-connection.close()
 ```
+
+Note that streaming automatically closes both cursor and connection once you have iterated over all results, to help prevent leaving connections open.
+
+```python
+In [26]: connection = connect(config_dict)
+
+In [27]: cur = connection.cursor()
+
+In [28]: cur.closed(), connection.closed()
+Out[28]: (False, False)
+
+In [29]: cur.execute(query)
+
+In [30]: for row in cur.iterate(): print row
+[datetime.datetime(2015, 4, 25, 14, 13, 19, tzinfo=<UTC>)]
+[datetime.datetime(2015, 4, 26, 6, 16, 14, tzinfo=<UTC>)]
+[datetime.datetime(2015, 4, 27, 18, 0, 32, tzinfo=<UTC>)]
+
+In [31]: cur.closed(), connection.closed()
+Out[31]: (True, True)
+
+```
+
 Streaming is recommended if you want to further process each row, save the results in a non-list/dict format (e.g. Pandas DataFrame), or save the results in a file.
 
 **In-memory** results as list:

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ for row in cur.iterate():
     print(row)
 # {'id': 1, 'value': 'something'}
 # {'id': 2, 'value': 'something_else'}
+
+connection.close()
 ```
 
-Note that streaming automatically closes both cursor and connection once you have iterated over all results, to help prevent leaving connections open.
+You can enable automatic closing of the cursor and connection after an iterator is emptied by setting the keyword argument `autoclose` to True:
 
 ```python
 In [26]: connection = connect(config_dict)
@@ -65,7 +67,7 @@ Out[28]: (False, False)
 
 In [29]: cur.execute(query)
 
-In [30]: for row in cur.iterate(): print row
+In [30]: for row in cur.iterate(autoclose=True): print row
 [datetime.datetime(2015, 4, 25, 14, 13, 19, tzinfo=<UTC>)]
 [datetime.datetime(2015, 4, 26, 6, 16, 14, tzinfo=<UTC>)]
 [datetime.datetime(2015, 4, 27, 18, 0, 32, tzinfo=<UTC>)]

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -91,6 +91,9 @@ class Cursor(object):
             yield row
             row = self.fetchone()
 
+        self.close()
+        self.connection.close()
+
     def fetchmany(self, size=None):
         if not size:
             size = self.arraysize

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -85,14 +85,15 @@ class Cursor(object):
         else:
             self.connection.process_message(self._message)
 
-    def iterate(self):
+    def iterate(self, autoclose=False):
         row = self.fetchone()
         while row:
             yield row
             row = self.fetchone()
 
-        self.close()
-        self.connection.close()
+        if autoclose:
+            self.close()
+            self.connection.close()
 
     def fetchmany(self, size=None):
         if not size:


### PR DESCRIPTION
...rating through query results iterable.

The goal is to prevent users from leaving connections and cursors open after they finish reading out the results of their queries.