### PR TITLE
Raise NotSupportedError for dates from BC era

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ nosetests.xml
 .pydevproject
 .DS_Store
 
+# vagrant
+.vagrant
+
 # pycharm
 /.idea/
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,57 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+#######################################################################
+# This will set up a box with Vertica Community Edition 7.1.1
+# running inside the box in a Docker container.
+#
+# The purpose is to have a Vertica instance that can be used by tests.
+#
+# Vertica's port 5433 is exposed to host machine.
+# Database 'docker' is available.
+# User is 'dbadmin' with no password.
+#
+# >>>
+# !   As is, any data stored inside Vertica will not live through
+# !   container or VM restart.
+# >>>
+#######################################################################
+
+
+# Globally install docker - bypass default Vagrant docker installation
+# procedure because it does not work reliably (curl does not follow
+# redirect = Docker won't be installed)
+
+$install_docker = <<SCRIPT
+curl -sSL https://get.docker.io | sh
+usermod -aG docker vagrant
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "phusion/ubuntu-14.04-amd64"
+
+  # Make Vertica available on host machine on port 5433
+  config.vm.network "forwarded_port", guest: 5433, host: 5433
+
+  config.vm.provider "virtualbox" do |v|
+     v.memory = 2048
+     v.cpus = 2
+  end
+
+  config.vm.provision "shell", inline: $install_docker
+
+  # Pull Vertica image when the box is first provisioned
+  config.vm.provision "docker" do |d|
+    d.pull_images 'sumitchawla/vertica:latest'
+  end
+
+  # Start Vertica inside container every time box is started
+  config.vm.provision "docker", run: "always" do |d|
+    d.run 'sumitchawla/vertica',
+    cmd: "",
+    args: "-d -p 5433:5433 --name vertica"
+  end
+
+end

--- a/vertica_python/tests/basic_tests.py
+++ b/vertica_python/tests/basic_tests.py
@@ -1,14 +1,11 @@
 import unittest
 import logging
 
+from test_commons import conn_info
+
 import vertica_python
 from vertica_python import errors
 
-conn_info = {'host': '127.0.0.1', 
-             'port': 5433, 
-             'user': 'dbadmin', 
-             'password': 'unit_test', 
-             'database': 'unit_test'}
 logger = logging.getLogger('vertica')
 
 
@@ -22,6 +19,7 @@ def init_table(cur):
                     b varchar(32)
                     ) ;
                 """)
+
 
 class TestVerticaPython(unittest.TestCase):
 

--- a/vertica_python/tests/date_tests.py
+++ b/vertica_python/tests/date_tests.py
@@ -1,0 +1,50 @@
+from datetime import date
+from test_commons import *
+from vertica_python import errors
+
+
+class DateParsingTestCase(VerticaTestCase):
+    """
+    Testing DATE type parsing with focus on AD/BC and lack of support for dates Before Christ.
+
+    Note: the 'BC' or 'AD' era indicators in Vertica's date format seem to make Vertica behave as follows:
+
+     - Both 'BC' and 'AD' are simply a flags that tell Vertica: include era indicator if the date is Before
+       Christ
+     - Dates in AD will never include era indicator
+    """
+    def _query_to_date(self, expression, pattern):
+        return self.query_and_fetchall("SELECT TO_DATE('%(expression)s', '%(pattern)s')" % locals())
+
+    def _assert_date(self, expression, pattern, expected):
+        res = self._query_to_date(expression, pattern)
+
+        if len(res) == 0:
+            self.fail("Expected that query '%(query)s' would return one row with one column. Got nothing." % locals())
+
+        elif len(res[0]) == 0:
+            self.fail("Expected that query '%(query)s' would return one row and one column. Got one row and no column."
+                      % locals())
+
+        self.assertEqual(expected, res[0][0], "Expected date '%s' but got: '%s'" % (str(expected), str(res[0][0])))
+
+    def test_after_christ(self):
+        self._assert_date('2000-01-01 AD', 'YYYY-MM-DD BC', date(2000, 1, 1))
+        self._assert_date('2000-01-01 AD', 'YYYY-MM-DD AD', date(2000, 1, 1))
+        self._assert_date('2000-01-01', 'YYYY-MM-DD', date(2000, 1, 1))
+
+    def test_before_christ_bc_indicator(self):
+        try:
+            res = self._query_to_date('2000-01-01 BC', 'YYYY-MM-DD BC')
+
+            self.fail("Expected to see NotSupportedError when Before Christ date is encountered. Got: " + str(res))
+        except errors.NotSupportedError:
+            pass
+
+    def test_before_christ_ad_indicator(self):
+        try:
+            res = self._query_to_date('2000-01-01 BC', 'YYYY-MM-DD AD')
+
+            self.fail("Expected to see NotSupportedError when Before Christ date is encountered. Got: " + str(res))
+        except errors.NotSupportedError:
+            pass

--- a/vertica_python/tests/test_commons.py
+++ b/vertica_python/tests/test_commons.py
@@ -1,0 +1,28 @@
+import unittest
+import os
+import vertica_python
+
+conn_info = {'host': os.getenv('VP_TEST_HOST', '127.0.0.1'),
+             'port': int(os.getenv('VP_TEST_PORT', 5433)),
+             'user': os.getenv('VP_TEST_USER', 'dbadmin'),
+             'password': os.getenv('VP_TEST_PASSWD', 'unit_test'),
+             'database': os.getenv('VP_TEST_DB', 'unit_test')}
+
+
+class VerticaTestCase(unittest.TestCase):
+    """
+    Base class for tests that query Vertica.
+
+    Implements a couple of functions for mindless repetetive tasks.
+    """
+    def query_and_fetchall(self, query):
+        """
+        Creates new connection to vertica, executes query, returns all fetched results. Closes connection.
+        :param query: query to execute
+        :return: all fetched results as returned by cursor.fetchall()
+        """
+        with vertica_python.connect(conn_info) as conn:
+            cur = conn.cursor()
+            cur.execute(query)
+
+            return cur.fetchall()


### PR DESCRIPTION
Parsing dates in BC era (say '1000-01-01 BC') resulted in ValueError while trying to convert to datetime.date. I have

* added code to identify BC dates and throw NotSupportedError instead (because date does not support BC)
* added couple of tests for this, minor refactoring in tests to separate out common config and code
* added Vagrant box with Vertica CE 7.1.1 so that it is easier to run tests on workstation

