### PR TITLE
Use kwargs

### DIFF
--- a/vertica_python/__init__.py
+++ b/vertica_python/__init__.py
@@ -25,6 +25,6 @@ threadsafety = 1
 paramstyle = 'named'  # WHERE name=:name
 
 
-def connect(options):
+def connect(**kwargs):
     """Opens a new connection to a Vertica database."""
-    return Connection(options)
+    return Connection(kwargs)


### PR DESCRIPTION
This doesn't follow the suggestion in PEP 0249 (https://www.python.org/dev/peps/pep-0249/#id40) for the connect method to utilize keyword arguments. This may seem pedantic, but in fact this will raise errors when trying to use a generic connect method. For example, you can't use a generic method to connect using MySQLdb or vertica-python.