### PR TITLE
Conflict resolution for copy stream (pull request #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ connection.commit()
 
 ```python
 cur = connection.cursor()
-cur.copy("COPY test_copy (id, name) from stdin DELIMITER ',' ",  "1,foo\n2,bar")
+cur.copy("COPY test_copy (id, name) from stdin DELIMITER ',' ",  csv)
 ```
+
+Where `csv` is either a string or a file-like object (specifically, any object with a `read()` method). If using a file, the data is streamed.
 
 
 ## License

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -100,13 +100,16 @@ class Column(object):
         self.scale = None
         self.null_ok = None
 
-        self.props = ColumnTuple(col['name'], col['data_type_oid'], None,
-                                 col['data_type_size'], None, None, None)
+        # WORKAROUND: Treat LONGVARCHAR as VARCHAR
+        if self.type_code == 115:
+            self.type_code = 9
 
-        try:
-            self.converter = self.DATA_TYPE_CONVERSIONS[col['data_type_oid']][1]
-        except IndexError:
-            self.converter = self.DATA_TYPE_CONVERSIONS[0][1]
+        #self.props = ColumnTuple(col['name'], col['data_type_oid'], None, col['data_type_size'], None, None, None)
+        self.props = ColumnTuple(col['name'], self.type_code, None, col['data_type_size'], None, None, None)
+
+        #self.converter = self.DATA_TYPE_CONVERSIONS[col['data_type_oid']][1]
+        self.converter = self.DATA_TYPE_CONVERSIONS[self.type_code][1]
+
         # things that are actually sent
 #        self.name = col['name']
 #        self.data_type = self.DATA_TYPE_CONVERSIONS[col['data_type_oid']][0]

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -131,12 +131,25 @@ class Connection(object):
 
     def write(self, message):
 
-        if hasattr(message, 'to_bytes') is False or callable(getattr(message, 'to_bytes')) is False:
+        is_stream = hasattr(message, "read_bytes")
+
+        if (hasattr(message, 'to_bytes') is False or callable(getattr(message, 'to_bytes')) is False) and not is_stream:
             raise TypeError("invalid message: ({0})".format(message))
 
         logger.debug('=> %s', message)
         try:
-            self._socket().sendall(message.to_bytes())
+
+            if not is_stream:
+                self._socket().sendall(message.to_bytes())
+            else:
+                # read to end in chunks
+                while True:
+                    data = message.read_bytes()
+                    if len(data) == 0:
+                        break
+
+                    self._socket().sendall(data)
+
         except Exception, e:
             self.close_socket()
             raise errors.ConnectionError(e.message)
@@ -193,6 +206,8 @@ class Connection(object):
         elif isinstance(message, messages.ReadyForQuery):
             self.transaction_status = message.transaction_status
         elif isinstance(message, messages.CommandComplete):
+            pass
+        elif isinstance(message, messages.CopyInResponse):
             pass
         else:
             raise errors.MessageError("Unhandled message: {0}".format(message))

--- a/vertica_python/vertica/messages/__init__.py
+++ b/vertica_python/vertica/messages/__init__.py
@@ -21,6 +21,7 @@ from frontend_messages.bind import Bind
 from frontend_messages.cancel_request import CancelRequest
 from frontend_messages.close import Close
 from frontend_messages.copy_data import CopyData
+from frontend_messages.copy_stream import CopyStream
 from frontend_messages.copy_done import CopyDone
 from frontend_messages.copy_fail import CopyFail
 from frontend_messages.describe import Describe

--- a/vertica_python/vertica/messages/frontend_messages/copy_stream.py
+++ b/vertica_python/vertica/messages/frontend_messages/copy_stream.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+from struct import pack
+
+from vertica_python.vertica.messages.message import FrontendMessage
+
+class CopyStream(FrontendMessage):
+
+    def __init__(self, stream, buffer_size=131072):
+        self.stream = stream
+        self.bufsize = buffer_size
+
+    def read_bytes(self):
+
+        data = self.stream.read(self.bufsize)
+
+        if len(data) == 0:
+            return data
+
+        return self.message_string(data)
+
+CopyStream._message_id('d')


### PR DESCRIPTION
This method for data streaming from a file seemed to be faster (and more logical) than the copy_file() method that was in master. 

For this resolution, I simply removed the copy amendments that had been made in another pull request. This will break copy_string() and copy_file(), but neither of those methods were added to the documentation and nothing else relies on them.