### PR TITLE
Flush messages before copy

### DIFF
--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -160,6 +160,8 @@ class Cursor(object):
         if self.closed():
             raise errors.Error('Cursor is closed')
 
+        self.flush_to_query_ready()
+
         self.connection.write(messages.Query(sql))
 
         while True:


### PR DESCRIPTION
If the messages status is not at ReadyForQuery before perform cur.copy(), such as
```
<vertica_python.vertica.messages.backend_messages.data_row.DataRow object at 0x10418fad0>
<vertica_python.vertica.messages.backend_messages.command_complete.CommandComplete object at 0x10418fc10>
```
It will cause QueryError while perform any sql after cur.copy().
```
/Users/alvin/.virtualenvs/test_vertica/lib/python2.7/site-packages/vertica_python/vertica/cursor.pyc in execute(self, operation, parameters)
     87             self._message = message
     88             if isinstance(message, messages.ErrorResponse):
---> 89                 raise errors.QueryError.from_error_response(message, operation)
     90             elif isinstance(message, messages.RowDescription):
     91                 self.description = map(lambda fd: Column(fd), message.fields)

QueryError: Severity: ERROR, Message: Unexpected message type 0x51, Sqlstate: 08V01, Routine: ??, File: /scratch_a/release/30493/vbuild/vertica/MsgProtocol/Server.cpp, Line: 482, SQL: 'select 1;'
```

Sample code:
```python
#!/usr/bin/env python
import vertica_python

conn_info = {'host': 'vertica.local','port': 5433, 'user': 'username', 'password': 'userpass', 'database': 'localdev'}

create_schema = """create schema if not exists copytest;
drop table if exists copytest.test_table;
create table copytest.test_table (
    id   INTEGER,
    name VARCHAR(32)
);"""

drop_schema = """drop schema if exists copytest cascade;"""

copy_sql = """COPY copytest.test_table (id,name)
             FROM STDIN
             DELIMITER '|'
             NULL AS 'None'"""

data = """1|name1
2|name2"""

## ==== create table ====
conn = vertica_python.connect(**conn_info)
cur = conn.cursor()
cur.execute(create_schema)
conn.close()

## ========================================
## ==== start of test ====
conn = vertica_python.connect(**conn_info)
cur = conn.cursor()

cur.execute("select 1;")
cur.fetchall()
# Current status: CommandComplete
cur.copy(copy_sql, data)
cur.execute("select 1;") # will raise QueryError here

conn.close()
## ==== end of test ====
```