### PR TITLE
change dict to OrderedDict in format_row_as_dict method to allow for preservation of column order during queries

### DIFF
--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import re
 import logging
 
+# from ordereddict import OrderedDict
 from collections import OrderedDict
 
 import vertica_python.errors as errors

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import re
 import logging
 
+from collections import OrderedDict
+
 import vertica_python.errors as errors
 
 import vertica_python.vertica.messages as messages
@@ -247,7 +249,7 @@ class Cursor(object):
             # throw some error
 
     def format_row_as_dict(self, row_data):
-        return dict(
+        return OrderedDict(
             (self.description[idx].name, self.description[idx].convert(value))
             for idx, value in enumerate(row_data.values)
         )

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import
 import re
 import logging
 
-# from ordereddict import OrderedDict
-from collections import OrderedDict
+from ordereddict import OrderedDict
 
 import vertica_python.errors as errors
 


### PR DESCRIPTION
In pandas (and more generally, in python), collections of unordered key-value pairs (such as a list of dicts to be converted to a DataFrame) are key-aligned by alphabetizing the keys. By changing this set of unordered key-value pairs to an ordered data structure (i.e. the OrderedDict) we can circumvent this problem and maintain column order.

This was a problem during queries -- I was querying Vertica and my columns were being alphabetized instead of preserving their original order. This workaround is hopefully a solution to avoid writing a million .loc statements in my Jupyter notebooks! :) 