### PR TITLE
Catch errors timestamp years are over 9999

### DIFF
--- a/vertica_python/tests/date_tests.py
+++ b/vertica_python/tests/date_tests.py
@@ -1,6 +1,7 @@
-from datetime import date
+from datetime import date, datetime
 from test_commons import *
 from vertica_python import errors
+from vertica_python.vertica.column import timestamp_parse
 
 
 class DateParsingTestCase(VerticaTestCase):
@@ -48,3 +49,23 @@ class DateParsingTestCase(VerticaTestCase):
             self.fail("Expected to see NotSupportedError when Before Christ date is encountered. Got: " + str(res))
         except errors.NotSupportedError:
             pass
+
+
+class TimestampParsingTestCase(VerticaTestCase):
+    """Verify timestamp parsing works properly."""
+
+
+    def test_timestamp_parser(self):
+        parsed_timestamp = timestamp_parse('1841-05-05 22:07:58')
+        # Assert parser default to strptime
+        self.assertEqual(datetime(year=1841, month=5, day=5, hour=22, minute=7, second=58), parsed_timestamp)
+
+    def test_timestamp_with_year_over_9999(self):
+        parsed_timestamp = timestamp_parse('44841-05-05 22:07:58')
+        # Assert year was truncated properly
+        self.assertEqual(datetime(year=4841, month=5, day=5, hour=22, minute=7, second=58), parsed_timestamp)
+
+    def test_timestamp_with_year_over_9999_and_ms(self):
+        parsed_timestamp = timestamp_parse('124841-05-05 22:07:58.000003')
+        # Assert year was truncated properly
+        self.assertEqual(datetime(year=4841, month=5, day=5, hour=22, minute=7, second=58, microsecond=3), parsed_timestamp)

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from collections import namedtuple
+import re
 
 from decimal import Decimal
 from datetime import date
@@ -9,6 +10,8 @@ from dateutil import parser
 from vertica_python import errors
 
 import pytz
+
+years_re = re.compile(r'^([0-9]+)-')
 
 
 # these methods are bad...
@@ -30,9 +33,29 @@ import pytz
 # timestamptz type stores: 2013-01-01 05:00:00.01+00
 #       select t AT TIMEZONE 'America/New_York' returns: 2012-12-31 19:00:00.01
 def timestamp_parse(s):
+    try:
+        dt = _timestamp_parse(s)
+    except ValueError:
+        # Value error, year might be over 9999
+        year_match = years_re.match(s)
+        if year_match:
+            year = year_match.groups()[0]
+        dt = _timestamp_parse_without_year(s[len(year) + 1:])
+        dt = dt.replace(year=int(year) % 10000)
+
+    return dt
+
+
+def _timestamp_parse(s):
     if len(s) == 19:
         return datetime.strptime(s, '%Y-%m-%d %H:%M:%S')
     return datetime.strptime(s, '%Y-%m-%d %H:%M:%S.%f')
+
+
+def _timestamp_parse_without_year(s):
+    if len(s) == 14:
+        return datetime.strptime(s, '%m-%d %H:%M:%S')
+    return datetime.strptime(s, '%m-%d %H:%M:%S.%f')
 
 
 def timestamp_tz_parse(s):

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -40,8 +40,10 @@ def timestamp_parse(s):
         year_match = years_re.match(s)
         if year_match:
             year = year_match.groups()[0]
-        dt = _timestamp_parse_without_year(s[len(year) + 1:])
-        dt = dt.replace(year=int(year) % 10000)
+            dt = _timestamp_parse_without_year(s[len(year) + 1:])
+            dt = dt.replace(year=int(year) % 10000)
+        else:
+            raise errors.DataError('Timestamp value not supported: %s' % s)
 
     return dt
 


### PR DESCRIPTION
Vertica can store timestamp with years over 9999 but python does not support it (https://docs.python.org/2/library/datetime.html#datetime.MAXYEAR).

This prevent errors in fetching the data by truncating the year to a 4 digit number.