### PR TITLE
Handle unknown data types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ opts = ReqOpts(None, 'git')
 # version should use the format 'x.x.x' (instead of 'vx.x.x')
 setup(
     name='vertica-python',
-    version='0.5.3',
+    version='0.5.4',
     description='A native Python client for the Vertica database.',
     author='Justin Berka, Alex Kim, Kenneth Tran',
     author_email='justin.berka@gmail.com, alex.kim@uber.com, tran@uber.com',

--- a/vertica_python/__init__.py
+++ b/vertica_python/__init__.py
@@ -6,7 +6,7 @@ from vertica_python.vertica.connection import Connection
 # Main module for this library.
 
 # The version number of this library.
-version_info = (0, 5, 2)
+version_info = (0, 5, 4)
 
 __version__ = '.'.join(map(str, version_info))
 

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -129,6 +129,10 @@ class Column(object):
         if self.type_code == 115:
             self.type_code = 9
 
+        # Mark type_code as unspecified if not within known data types
+        if self.type_code >= len(self.DATA_TYPE_CONVERSIONS):
+            self.type_code = 0
+
         #self.props = ColumnTuple(col['name'], col['data_type_oid'], None, col['data_type_size'], None, None, None)
         self.props = ColumnTuple(col['name'], self.type_code, None, col['data_type_size'], None, None, None)
 


### PR DESCRIPTION
Vertica can pass down data types that are unknown from vertica-python and would result in an IndexError when fetching proper conversion methods. This default all unknowns types to 'unspecified'