### PR TITLE
Use unicode word boundaries

### DIFF
--- a/vertica_python/tests/unicode_tests.py
+++ b/vertica_python/tests/unicode_tests.py
@@ -1,0 +1,16 @@
+from .test_commons import conn_info, VerticaTestCase
+from .. import connect
+
+
+class UnicodeTestCase(VerticaTestCase):
+    def test_unicode_named_parameter_binding(self):
+        key = u'\u16a0'
+        value = 1
+        query = u"SELECT :%s" % key
+
+        with connect(**conn_info) as conn:
+            cur = conn.cursor()
+            cur.execute(query, {key: value})
+            res = cur.fetchone()
+
+            assert res[0] == value

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -64,7 +64,7 @@ class Cursor(object):
                     # Using a regex with word boundary to correctly handle params with similar names
                     # such as :s and :start
                     match_str = u':%s\\b' % unicode(key)
-                    operation = re.sub(match_str, v.decode('utf-8'), operation, re.UNICODE)
+                    operation = re.sub(match_str, v.decode('utf-8'), operation, flags=re.UNICODE)
             elif isinstance(parameters, tuple):
                 tlist = []
                 for p in parameters:


### PR DESCRIPTION
Correctly use unicode word boundaries when binding named parameters in a query. This was attempted previously, but the actual `re.sub` call put the `re.UNICODE` flag in the `count` parameter instead of the `flag` parameter.