### PR TITLE
Avoids silent weirdness from conn.cursor(dict)

### DIFF
--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -238,13 +238,14 @@ class Cursor(object):
         return self._closed or self.connection.closed()
 
     def row_formatter(self, row_data):
-        if not self.cursor_type:
+        if self.cursor_type is None:
             return self.format_row_as_array(row_data)
-        elif self.cursor_type == 'list':
+        elif self.cursor_type in (list, 'list'):
             return self.format_row_as_array(row_data)
-        elif self.cursor_type == 'dict':
+        elif self.cursor_type in (dict, 'dict'):
             return self.format_row_as_dict(row_data)
-            # throw some error
+        else:
+            raise Exception('Unrecognized cursor_type: %r' % self.cursor_type)
 
     def format_row_as_dict(self, row_data):
         return dict(


### PR DESCRIPTION
connection.cursor('dict') works as expected, but connection.cursor(dict) surprisingly returns empty query results.

This commit makes passing dict or 'dict' equavalent when passed to conn.cursor, and a noisy error if any unhandled value is passed as the cursor_type.