### PR TITLE
Add more error classes

### DIFF
--- a/vertica_python/errors.py
+++ b/vertica_python/errors.py
@@ -109,6 +109,10 @@ class VerticaSyntaxError(QueryError):
     pass
 
 
+class MissingSchema(QueryError):
+    pass
+
+
 class MissingRelation(QueryError):
     pass
 
@@ -129,14 +133,20 @@ class InvalidDatetimeFormat(QueryError):
     pass
 
 
+class DuplicateObject(QueryError):
+    pass
+
+
 QUERY_ERROR_CLASSES = {
     b'55V03': LockFailure,
     b'53000': InsufficientResources,
     b'53200': OutOfMemory,
     b'42601': VerticaSyntaxError,
+    b'3F000': MissingSchema,
     b'42V01': MissingRelation,
     b'42703': MissingColumn,
     b'22V04': CopyRejected,
     b'42501': PermissionDenied,
-    b'22007': InvalidDatetimeFormat
+    b'22007': InvalidDatetimeFormat,
+    b'42710': DuplicateObject
 }

--- a/vertica_python/tests/error_tests.py
+++ b/vertica_python/tests/error_tests.py
@@ -1,0 +1,62 @@
+from .test_commons import conn_info, VerticaTestCase
+from .. import connect
+from .. import errors
+
+
+class ErrorTestCase(VerticaTestCase):
+
+    def test_missing_schema(self):
+
+        query = "SELECT 1 FROM missing_schema.table"
+
+        with connect(**conn_info) as conn:
+            cur = conn.cursor()
+
+            failed = False
+
+            try:
+                cur.execute(query)
+            except errors.MissingSchema:
+                failed = True
+
+            assert failed is True
+
+    def test_missing_relation(self):
+
+        query = "SELECT 1 FROM missing_table"
+
+        with connect(**conn_info) as conn:
+            cur = conn.cursor()
+
+            failed = False
+
+            try:
+                cur.execute(query)
+            except errors.MissingRelation:
+                failed = True
+
+            assert failed is True
+
+    def test_duplicate_object(self):
+
+        create = "CREATE TABLE test_table (a BOOLEAN)"
+        drop = "DROP TABLE test_table"
+
+        with connect(**conn_info) as conn:
+            cur = conn.cursor()
+
+            failed = False
+
+            cur.execute(create)
+
+            try:
+                cur.execute(create)
+            except errors.DuplicateObject:
+                failed = True
+            finally:
+                try:
+                    cur.execute(drop)
+                except errors.MissingRelation:
+                    pass
+
+            assert failed is True

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -217,6 +217,10 @@ class Cursor(object):
 
         while True:
             message = self.connection.read_message()
+
+            if isinstance(message, messages.ErrorResponse):
+                raise errors.QueryError.from_error_response(message, sql)
+
             self.connection.process_message(message=message)
             if isinstance(message, messages.ReadyForQuery):
                 break


### PR DESCRIPTION
Add error classes for the scenarios when:

 * The schema is missing
 * The object that is to be created already exists