### PR TITLE
Better unicode named parameter test

### DIFF
--- a/vertica_python/tests/unicode_tests.py
+++ b/vertica_python/tests/unicode_tests.py
@@ -5,7 +5,7 @@ from .. import connect
 class UnicodeTestCase(VerticaTestCase):
     def test_unicode_query(self):
         value = u'\u16a0'
-        query = u"SELECT '%s'" % value
+        query = u"SELECT '{}'".format(value)
 
         with connect(**conn_info) as conn:
             cur = conn.cursor()
@@ -16,8 +16,8 @@ class UnicodeTestCase(VerticaTestCase):
 
     def test_unicode_named_parameter_binding(self):
         key = u'\u16a0'
-        value = 1
-        query = u"SELECT :%s" % key
+        value = u'\u16b1'
+        query = u"SELECT :{}".format(key)
 
         with connect(**conn_info) as conn:
             cur = conn.cursor()


### PR DESCRIPTION
Improve the unicode named parameter test to use non-standard characters
for both the key and value parts of the parameters.