### PR TITLE
Allow StartTLS response to be ascii or bytes (py3k)

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -113,7 +113,7 @@ class Connection(object):
             from ssl import CertificateError, SSLError
             raw_socket.sendall(messages.SslRequest().to_bytes())
             response = raw_socket.recv(1)
-            if response == 'S':
+            if response in ('S', b'S'):
                 try:
                     if isinstance(ssl_options, ssl.SSLContext):
                         raw_socket = ssl_options.wrap_socket(raw_socket, server_hostname=host)


### PR DESCRIPTION
SSL connections in Python 3 aren't working due to a minor bug where an equality test is done on the StartTLS response, checking if it's 'S', whereas in Python 3 the response is b'S'.  