### PR TITLE
fixed issue #116 where column names were bytes objects instead of strings

### DIFF
--- a/vertica_python/tests/column_tests.py
+++ b/vertica_python/tests/column_tests.py
@@ -1,0 +1,21 @@
+from .test_commons import conn_info, VerticaTestCase
+from .. import connect
+
+
+class ColumnTestCase(VerticaTestCase):
+    def test_column_names_query(self):
+        column_0 = 'isocode'
+        column_1 = 'name'
+        query = """
+        select 'US' as {column_0}, 'United States' as {column_1}
+        union all
+        select 'CA', 'Canada'
+        union all
+        select 'MX', 'Mexico'
+        """.format(column_0=column_0, column_1=column_1)
+        with connect(**conn_info) as conn:
+            cur = conn.cursor()
+            cur.execute(query)
+            description = cur.description
+            assert description[0].name == column_0
+            assert description[1].name == column_1

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -124,7 +124,7 @@ class Column(object):
         return map(lambda x: x[0], Column.data_type_conversions())
 
     def __init__(self, col, unicode_error=None):
-        self.name = col['name']
+        self.name = col['name'].decode()
         self.type_code = col['data_type_oid']
         self.display_size = None
         self.internal_size = col['data_type_size']
@@ -143,7 +143,7 @@ class Column(object):
             self.type_code = 0
 
         #self.props = ColumnTuple(col['name'], col['data_type_oid'], None, col['data_type_size'], None, None, None)
-        self.props = ColumnTuple(col['name'], self.type_code, None, col['data_type_size'], None, None, None)
+        self.props = ColumnTuple(self.name, self.type_code, None, col['data_type_size'], None, None, None)
 
         #self.converter = self.data_type_conversions[col['data_type_oid']][1]
         self.converter = self.data_type_conversions[self.type_code][1]


### PR DESCRIPTION
This addresses an issue in vertica-python when run in Python3 where column names are bytes objects instead of utf-8 encoded strings.  Also added a test case that fails in Python3 before this PR and succeeds after.  (Note: Tests fail under python3.5 for `test_unicode_named_parameter_binding` even from master.  This doesn't do anything to address that.)

The issue #116 has some examples of queries and resulting column names for pandas dataframes.

If there is a better way to handle this in a Python 2/3 compatible way, please let me know.  I did what I thought was most expedient but if the library as a whole has a preferred way to handle bytes/strings in a compatible way, I'll be happy to follow the lead.