### PR TITLE
fixed parsing of Timestamp and TimestampTz columns in Python3

### DIFF
--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -34,6 +34,7 @@ years_re = re.compile(r'^([0-9]+)-')
 # timestamptz type stores: 2013-01-01 05:00:00.01+00
 #       select t AT TIMEZONE 'America/New_York' returns: 2012-12-31 19:00:00.01
 def timestamp_parse(s):
+    s = str(s, 'utf-8')
     try:
         dt = _timestamp_parse(s)
     except ValueError:
@@ -62,6 +63,7 @@ def _timestamp_parse_without_year(s):
 
 
 def timestamp_tz_parse(s):
+    s = str(s, 'utf-8')
     # if timezome is simply UTC...
     if s.endswith('+00'):
         # remove time zone


### PR DESCRIPTION
This modifies `timestamp_parse` and `timestamp_tz_parse` to coerce the argument to a utf-8 encode string.  In Python2 the argument is already a string while in Python3 it is a bytes object.

These three queries threw exceptions that are fixed by this PR:
```
connection = vertica_python.connect(**config)
cursor = connection.cursor()

# calls timestamp_parse
query = """
select
  to_timestamp('2016-05-15 13:15:17.789', 'YYYY-MM-DD HH:MI:SS.MS')
;
"""
cursor.execute(query)
cursor.fetchall()

# calls timestamp_tz_parse
query = """
select
  to_timestamp_tz('2016-05-15 13:15:17.789 UTC', 'YYYY-MM-DD HH:MI:SS.MS TZ')
;
"""
cursor.execute(query)
cursor.fetchall()

# calls timestamp_tz_parse
query = """
select
  timestamp '2016-05-15 13:15:17.789+00'
;
"""
cursor.execute(query)
cursor.fetchall()
```

It may be that we should be coercing to unicode somewhere before the parse methods are called.  Let me know if that is the case and I can move it sooner in the pipeline.

thanks,
Dennis