### PR TITLE
Fix exception in the `connection.ssl()` function

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -130,7 +130,7 @@ class Connection(object):
         return self.socket
 
     def ssl(self):
-        return self.socket is not None and isinstance(ssl.SSLSocket, self.socket)
+        return self.socket is not None and isinstance(self.socket, ssl.SSLSocket)
 
     def opened(self):
         return (self.socket is not None


### PR DESCRIPTION
The arguments to `isinstance()` inside the `connection.ssl()` function were flipped, causing an exception.

Just a quick fix for this. :)