### PR TITLE
Removed (unused?) ordereddict from build requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     install_requires=[
         'python-dateutil>=1.5',
         'pytz',
-        'ordereddict==1.1',
         'future'
     ],
     extras_require={'namedparams': ['psycopg2>=2.5.1']},


### PR DESCRIPTION
`ordereddict` doesn't seem to be invoked anywhere in the code; rather `from collection import OrderedDict` is. As such, the backporting library seems unnecessary.