### PR TITLE
Fixes broken md5 auth in python 3 with minor bytes/unicode distinction 

### DIFF
--- a/vertica_python/vertica/messages/frontend_messages/password.py
+++ b/vertica_python/vertica/messages/frontend_messages/password.py
@@ -14,6 +14,13 @@ from vertica_python.vertica.messages.message import FrontendMessage
 from vertica_python.vertica.messages.backend_messages.authentication import Authentication
 
 
+try:
+    basestring
+    PY3 = False
+except NameError:
+    PY3 = True
+
+
 class Password(FrontendMessage):
 
     def __init__(self, password, auth_method=None, options=None):

--- a/vertica_python/vertica/messages/frontend_messages/password.py
+++ b/vertica_python/vertica/messages/frontend_messages/password.py
@@ -10,15 +10,9 @@ import hashlib
 
 from struct import pack
 
+import six
 from vertica_python.vertica.messages.message import FrontendMessage
 from vertica_python.vertica.messages.backend_messages.authentication import Authentication
-
-
-try:
-    basestring
-    PY3 = False
-except NameError:
-    PY3 = True
 
 
 class Password(FrontendMessage):


### PR DESCRIPTION
Md5 auth is broken in python3 due to m.hexdigest() outputting a unicode string rather than bytes in python3. This set of changes puts a six.PY3 check in place and encodes the unicode as bytes while computing the md5 digest. cc @nchammas @merritts