### PR TITLE
Enable keepalive on socket.

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -106,6 +106,7 @@ class Connection(object):
         host = self.options.get('host')
         port = self.options.get('port')
         raw_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        raw_socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         raw_socket.connect((host, port))
 
         ssl_options = self.options.get('ssl')


### PR DESCRIPTION
Long-running queries are at risk of being terminated or reset by the remote host because tcp keepalive is not enabled on Linux sockets by default. This enables keepalive on the socket.