### PR TITLE
Prevents psycopg2 from appending ::bytea to stringy named params in python 3

### DIFF
--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -54,16 +54,16 @@ class Cursor(object):
 
         if parameters:
             # # optional requirement
+            import six
             from psycopg2.extensions import adapt
 
             if isinstance(parameters, dict):
                 for key in parameters:
                     param = parameters[key]
                     # Make sure adapt() behaves properly
-                    if isinstance(param, str):
-                        v = adapt(param.encode('utf8')).getquoted()
-                    else:
-                        v = adapt(param).getquoted()
+                    if six.PY2:
+                        param = param.encode('utf8')
+                    v = adapt(param).getquoted()
 
                     # Using a regex with word boundary to correctly handle params with similar names
                     # such as :s and :start


### PR DESCRIPTION
Fixes #112 by checking the python version before invoking psycopg2's adapt function; if it's python 2 it first encodes the value to bytes, and if python 3, it doesn't encode to bytes. 

cc @merritts @nchammas