### PR TITLE
Fixes python3 bytes/unicode comparison issue for bool column data_type_conversion  

### DIFF
--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -105,7 +105,7 @@ class Column(object):
             ('pos', None),
             ('record', None),
             ('unknown', None),
-            ('bool', lambda s: str(s, 'utf-8', unicode_error)),
+            ('bool', lambda s: 't' == str(s, 'utf-8', unicode_error)),
             ('integer', lambda s: int(s)),
             ('float', lambda s: float(s)),
             ('char', lambda s: str(s, 'utf-8', unicode_error)),

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -105,7 +105,7 @@ class Column(object):
             ('pos', None),
             ('record', None),
             ('unknown', None),
-            ('bool', lambda s: s == 't'),
+            ('bool', lambda s: str(s, 'utf-8', unicode_error)),
             ('integer', lambda s: int(s)),
             ('float', lambda s: float(s)),
             ('char', lambda s: str(s, 'utf-8', unicode_error)),


### PR DESCRIPTION
There's a bug in the boolean data type converter that doesn't raise an error but results in all boolean values getting silently altered to False under python 3 due the inequality of b't' and 't'. The fix applies the same str(s, 'utf-8', unicode_error) used in the other data type conversion functions. If there's anything more needed for this, please let me know. Thank you! @merritts @nchammas @mukssharma