### PR TITLE
Fix parsing responses that contain no data

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -215,6 +215,8 @@ class Connection(object):
             #if hasattr(message, 'rows'):
             #    self.cursor.rowcount = message.rows
             pass
+        elif isinstance(message, messages.EmptyQueryResponse):
+            pass
         elif isinstance(message, messages.CopyInResponse):
             pass
         else:

--- a/vertica_python/vertica/messages/backend_messages/empty_query_response.py
+++ b/vertica_python/vertica/messages/backend_messages/empty_query_response.py
@@ -4,7 +4,8 @@ from vertica_python.vertica.messages.message import BackendMessage
 
 
 class EmptyQueryResponse(BackendMessage):
-    pass
+    def __init__(self, data=None):
+        self.data = data
 
 
 EmptyQueryResponse._message_id(b'I')

--- a/vertica_python/vertica/messages/message.py
+++ b/vertica_python/vertica/messages/message.py
@@ -45,7 +45,7 @@ class BackendMessage(Message):
         if klass is not None:
             return klass(data)
         else:
-            return messages.Unknown(type_, data)
+            return Unknown(type_, data)
 
     @classmethod
     def _message_id(cls, message_id):


### PR DESCRIPTION
This is a fix for issue #143 .

Added an __init__ method so that the default object one will not be called, and added an elif block in connection.py in order to handle EmptyQueryResponse bubbling up the call stack.

Updated initialization of Unknown type in message.py as calling with full path `message.py` was erring as all types are imported at top of module.