### PR TITLE
Adding the ability to set the socket timeout in the connection dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ conn_info = {'host': '127.0.0.1',
              # default throw error on invalid UTF-8 results
              'unicode_error': 'strict',
              # SSL is disabled by default
-             'ssl': False}
+             'ssl': False,
+             'connection_timeout': 5
+             # connection timeout is not enabled by default}
 
 # simple connection, with manual close
 connection = vertica_python.connect(**conn_info)

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -105,8 +105,11 @@ class Connection(object):
 
         host = self.options.get('host')
         port = self.options.get('port')
+        connection_timeout = self.options.get('connection_timeout')
         raw_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         raw_socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        if connection_timeout is not None:
+            raw_socket.settimeout(connection_timeout)
         raw_socket.connect((host, port))
 
         ssl_options = self.options.get('ssl')


### PR DESCRIPTION
Adding the ability to set the socket timeout in the connection dict allows for a more predictable and timely experience in the event that the host is unreachable.