### PR TITLE
Maintain compatibility with Python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ opts = ReqOpts(None, 'git')
 # version should use the format 'x.x.x' (instead of 'vx.x.x')
 setup(
     name='vertica-python',
-    version='0.6.14',
+    version='0.6.16',
     description='A native Python client for the Vertica database.',
     author='Justin Berka, Alex Kim',
     author_email='justin.berka@gmail.com, alex.kim@uber.com',

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -3,7 +3,11 @@
 import re
 import logging
 
-from collections import OrderedDict
+try:
+    from collections import OrderedDict  # python 2.7+ / 3
+except ImportError:
+    from ordereddict import OrderedDict  # python 2.6
+
 from builtins import str
 
 import vertica_python.errors as errors


### PR DESCRIPTION
This change adds back the ability to run under 2.6 as well as 2.7+ and 3