### PR TITLE
Add cancel() to Cursor and Connection

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -13,6 +13,7 @@ from .. import errors
 from ..vertica import messages
 from ..vertica.cursor import Cursor
 from ..vertica.messages.message import BackendMessage, FrontendMessage
+from ..vertica.messages.frontend_messages import CancelRequest
 
 logger = logging.getLogger('vertica')
 
@@ -67,6 +68,12 @@ class Connection(object):
             self.write(messages.Terminate())
         finally:
             self.close_socket()
+
+    def cancel(self):
+        if self.closed():
+            raise errors.ConnectionError('Connection is closed')
+
+        self.write(CancelRequest(backend_pid=self.backend_pid, backend_key=self.backend_key))
 
     def commit(self):
         if self.closed():

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 import re
+
 try:
     from collections import OrderedDict  # python 2.7+ / 3
 except ImportError:
@@ -80,6 +81,12 @@ class Cursor(object):
 
     def close(self):
         self._closed = True
+
+    def cancel(self):
+        if self.closed():
+            raise errors.Error('Cursor is closed')
+
+        self.connection.close()
 
     def execute(self, operation, parameters=None):
         self.operation = as_text(operation)


### PR DESCRIPTION
The cancel() method is intended for interactive sessions.

Maybe we should add
```python
except KeyboardInterrupt:
    cur.cancel()
```
or something similar in some methods?