### PR TITLE
Bug fix in BackendMessage.from_type()

### DIFF
--- a/vertica_python/vertica/messages/message.py
+++ b/vertica_python/vertica/messages/message.py
@@ -46,6 +46,7 @@ class BackendMessage(Message):
         if klass is not None:
             return klass(data)
         else:
+            from .backend_messages import Unknown
             return Unknown(type_, data)
 
     @staticmethod


### PR DESCRIPTION
import `Unknown` in the method scope (and not in the top-level scope) to prevent circular dependencies.