### PR TITLE
Bug Fix for executemany

### DIFF
--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -362,7 +362,7 @@ class Cursor(object):
 
                 tlist.append(value)
 
-            operation = operation % tuple(tlist)
+            operation = operation.format(tuple(tlist))
         else:
             raise errors.Error("Argument 'parameters' must be dict or tuple")
 


### PR DESCRIPTION
There is a case where my dataframe is failing to be replaced in the statement             operation = operation.format(tuple(tlist))
 in cursor.py .. 