### PR TITLE
test_cursor:test_copy_with_file testcase fix:

### DIFF
--- a/vertica_python/tests/test_cursor.py
+++ b/vertica_python/tests/test_cursor.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import logging
+import os as _os
 import tempfile
 
 from .base import VerticaPythonTestCase
@@ -153,12 +154,16 @@ class CursorTestCase(VerticaPythonTestCase):
             self.assertListOfListsEqual(res_from_cur2, [[2, 'bar']])
 
     def test_copy_with_file(self):
-        f = tempfile.TemporaryFile()
-        f.write(b"1,foo\n2,bar")
-        # move rw pointer to top of file
-        f.seek(0)
+        with tempfile.TemporaryFile() as tmpfile, self._connect() as conn1, self._connect() as conn2:
+            if _os.name != 'posix' or _os.sys.platform == 'cygwin':
+                f = getattr(tmpfile, 'file')
+            else:
+                f = tmpfile
 
-        with self._connect() as conn1, self._connect() as conn2:
+            f.write(b"1,foo\n2,bar")
+            # move rw pointer to top of file
+            f.seek(0)
+
             cur1 = conn1.cursor()
             cur2 = conn2.cursor()
 


### PR DESCRIPTION
-test case fails on windows platform (probably fails on few other platforms)
-On a few platforms, tempfile.TempFile() creates file-like wrapper objects that contain the file objects causing the cursor to raise an exception
-Added the same check that returns the temp file object to get the file object (for the check refer tempfile module: line 540)
-file objects haven't been properly closed, causing the temp files to persist. Fixed this by moving the file handling logic to context manager