### PR TITLE
making client label connection customizable

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -278,8 +278,9 @@ class Connection(object):
         user = self.options['user'].encode(ASCII)
         database = self.options['database'].encode(ASCII)
         password = self.options['password'].encode(ASCII)
+        label = self.options['label'].encode(ASCII) if 'label' in self.options else None
 
-        self.write(messages.Startup(user, database))
+        self.write(messages.Startup(user, database, label))
 
         while True:
             message = self.read_message()

--- a/vertica_python/vertica/messages/frontend_messages/startup.py
+++ b/vertica_python/vertica/messages/frontend_messages/startup.py
@@ -37,7 +37,7 @@ ASCII = 'ascii'
 class Startup(BulkFrontendMessage):
     message_id = None
 
-    def __init__(self, user, database, options=None):
+    def __init__(self, user, database, label=None, options=None):
         BulkFrontendMessage.__init__(self)
 
         self._user = user
@@ -47,7 +47,7 @@ class Startup(BulkFrontendMessage):
         self._version = vertica_python.__version__.encode(ASCII)
         self._platform = platform.platform().encode(ASCII)
         self._pid = '{0}'.format(os.getpid()).encode(ASCII)
-        self._label = self._type + b'-' + self._version + b'-' + str(uuid.uuid1()).encode(ASCII)
+        self._label = self._type + b'-' + self._version + b'-' + str(uuid.uuid1()).encode(ASCII) if label is None else label
 
     def read_bytes(self):
         bytes_ = pack('!I', vertica_python.PROTOCOL_VERSION)


### PR DESCRIPTION
While keeping the default client label set by https://github.com/uber/vertica-python/issues/100 ,
this commit allows users to customize their client label