### PR TITLE
Revert "Updating license type from MIT to Apache 2.0."

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ cur.fetchone()
 
 ## License
 
-Apache 2.0 License, please see `LICENSE` for details.
+MIT License, please see `LICENSE` for details.
 
 
 ## Acknowledgements


### PR DESCRIPTION
Reverts uber/vertica-python#200

I am reverting the relicensing on behalf of Uber's open source program office. We will look into the changes and take appropriate actions. 